### PR TITLE
Remove backend directory from build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Gravus - a minimalistic fitness tracker application.",
   "main": "index.js",
   "scripts": {
-    "start": "node backend/server.js",
-    "dev": "nodemon backend/server.js",
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "prepare": "husky"
   },
   "repository": {


### PR DESCRIPTION
- npm start & npm dev scripts were pointing to /backend/server.js. Remove backend reference, as the project file structure was changed and the server.js file exists in the root dir now.